### PR TITLE
fix MarkerClient and MarkerArrayClient unsubscribe

### DIFF
--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -60,7 +60,7 @@ ROS3D.MarkerArrayClient.prototype.subscribe = function(){
     messageType : 'visualization_msgs/MarkerArray',
     compression : 'png'
   });
-  this.rosTopic.subscribe(() => this.processMessage;
+  this.rosTopic.subscribe(() => this.processMessage);
 };
 
 ROS3D.MarkerArrayClient.prototype.processMessage = function(arrayMessage){

--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -60,7 +60,7 @@ ROS3D.MarkerArrayClient.prototype.subscribe = function(){
     messageType : 'visualization_msgs/MarkerArray',
     compression : 'png'
   });
-  this.rosTopic.subscribe(this.processMessage.bind(this));
+  this.rosTopic.subscribe(() => this.processMessage;
 };
 
 ROS3D.MarkerArrayClient.prototype.processMessage = function(arrayMessage){

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -66,7 +66,7 @@ ROS3D.MarkerClient.prototype.subscribe = function(){
     messageType : 'visualization_msgs/Marker',
     compression : 'png'
   });
-  this.rosTopic.subscribe(this.processMessage.bind(this));
+  this.rosTopic.subscribe(() => this.processMessage);
 };
 
 ROS3D.MarkerClient.prototype.processMessage = function(message){


### PR DESCRIPTION
`this.processMessage.bind(this)` creates a different function signature from `this.processMessage`, meaning that currently the unsubscribe method doesn't actually work. This should fix that problem.